### PR TITLE
Support beta discord builds Webhook URL

### DIFF
--- a/modules/Sender.mjs
+++ b/modules/Sender.mjs
@@ -73,7 +73,7 @@ export class Sender {
         Promise.allSettled(
             webhook_urls.map((url) => {
 
-                const parsedUrl = /https:\/\/discord(?:app)?\.com\/api\/webhooks\/([^]+)\/([^/]+)/g.exec(url);
+                const parsedUrl = /https:\/\/(?:\w+\.)?discord(?:app)?\.com\/api\/webhooks\/([^]+)\/([^/]+)/g.exec(url);
 
                 if (parsedUrl) {
                     const [, id, token] = parsedUrl;


### PR DESCRIPTION
Столкнулся с проблемой, что скрипт не съедает ссылки, сгенерированные PTB билдом дискорда, сразу стало ясно, что данный сценарий не обрабатывается в RegExp, недолго покопавшись, состряпал дополнительную non-capture группу, дабы парсить данный момент