### PR TITLE
Use `gha` docker build caching

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -27,9 +27,9 @@ jobs:
         with:
           push: true
           tags: mrzillagold/vk2discord:latest
-          build-args: |
-            arg1=value1
-            arg2=value2
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
       -
         name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
As described at [docs](https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md) build may be cached w/ buildkit due to speedup builds